### PR TITLE
Fix wrong data from the persistent storage

### DIFF
--- a/src/FDBFactory.ts
+++ b/src/FDBFactory.ts
@@ -215,24 +215,24 @@ const openDatabase = (
     }
 
     if (version === undefined) {
-        version = db.version !== 0 ? db.version : 1;
+        version = db?.version !== 0 ? db?.version : 1;
     }
 
-    if (db.version > version) {
+    if (db?.version && db.version > version!) {
         return cb(new VersionError());
     }
 
-    const connection = new FDBDatabase(db);
+    const connection = new FDBDatabase(db!);
 
-    if (isNewDatabase || db.version < version) {
-        runVersionchangeTransaction(connection, version, request, (err) => {
+    if (isNewDatabase || db!.version < version!) {
+        runVersionchangeTransaction(connection, version!, request, (err) => {
             if (err) {
                 // Ensure that connection is closed before aborting
                 connection.close();
                 return cb(err);
             }
 
-            dbManager.saveDatabaseStructure(db);
+            dbManager.saveDatabaseStructure(db!);
 
             cb(null, connection);
         });

--- a/src/lib/Database.ts
+++ b/src/lib/Database.ts
@@ -3,7 +3,7 @@ import FDBTransaction from "../FDBTransaction.js";
 import ObjectStore from "./ObjectStore.js";
 import { queueTask } from "./scheduling.js";
 import dbManager from "./LevelDBManager.js";
-import { DatabaseStructure } from "./types.js";
+
 // http://www.w3.org/TR/2015/REC-IndexedDB-20150108/#dfn-database
 class Database {
     public deletePending = false;

--- a/src/lib/Index.ts
+++ b/src/lib/Index.ts
@@ -31,7 +31,7 @@ class Index {
         // this.records.setKeyPrefix(); //is this right? or should the index name not be there?
         this.name = name;
         const keyPrefix = `${this.rawObjectStore.rawDatabase.name}/${this.rawObjectStore.name}/${this.name}/`;
-        this.records = new RecordStore(keyPrefix);
+        this.records = new RecordStore(keyPrefix, "index");
         this.keyPath = keyPath;
         this.multiEntry = multiEntry;
         this.unique = unique;

--- a/src/lib/LevelDBManager.ts
+++ b/src/lib/LevelDBManager.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import { Level } from "level";
-import { Record, KeyPath, DatabaseStructure } from "./types.js";
+import { Record, DatabaseStructure } from "./types.js";
 import Database from "./Database.js";
 
 class LevelDBManager {
@@ -170,7 +170,7 @@ class LevelDBManager {
         if (!this.isLoaded) throw new Error("Database not loaded yet");
         return Array.from(this.cache.entries())
             .filter(([key]) => key.startsWith(prefix))
-            .map(([_, value]) => value);
+            .map(([, value]) => value);
     }
 }
 

--- a/src/lib/LevelDBManager.ts
+++ b/src/lib/LevelDBManager.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 import { Level } from "level";
 import { Record, DatabaseStructure } from "./types.js";
 import Database from "./Database.js";
+import { RecordStoreType, SEPARATOR } from "./RecordStore.js";
 
 class LevelDBManager {
     private static instance: LevelDBManager;
@@ -166,10 +167,15 @@ class LevelDBManager {
         );
     }
 
-    public getValuesForKeysStartingWith(prefix: string): Record[] {
+    public getValuesForKeysStartingWith(
+        prefix: string,
+        type: RecordStoreType,
+    ): Record[] {
         if (!this.isLoaded) throw new Error("Database not loaded yet");
+        const validatedPrefix = type + SEPARATOR + prefix;
+
         return Array.from(this.cache.entries())
-            .filter(([key]) => key.startsWith(prefix))
+            .filter(([key]) => key.startsWith(validatedPrefix))
             .map(([, value]) => value);
     }
 }

--- a/src/lib/ObjectStore.ts
+++ b/src/lib/ObjectStore.ts
@@ -32,7 +32,7 @@ class ObjectStore {
         this.keyPath = keyPath;
         this.autoIncrement = autoIncrement;
         const keyPrefix = `${this.rawDatabase.name}/${this.name}/`;
-        this.records = new RecordStore(keyPrefix);
+        this.records = new RecordStore(keyPrefix, "object");
         // this.records.setKeyPrefix(keyPrefix);
         // console.log(
         //     "IDB|ObjectStore constructor,",

--- a/src/lib/RecordStore.ts
+++ b/src/lib/RecordStore.ts
@@ -10,12 +10,17 @@ import cmp from "./cmp.js";
 import { Key, Record } from "./types.js";
 import dbManager from "./LevelDBManager.js";
 
+export type RecordStoreType = "object" | "index";
+export const SEPARATOR = "_";
+
 class RecordStore {
     private records: Record[] = [];
     private keyPrefix: string;
-
-    constructor(keyPrefix: string) {
+    private type: RecordStoreType;
+    constructor(keyPrefix: string, type: RecordStoreType) {
         this.keyPrefix = keyPrefix;
+        this.type = type;
+
         this.loadRecordsFromCache();
     }
 
@@ -27,6 +32,7 @@ class RecordStore {
         }
         const cachedRecords = dbManager.getValuesForKeysStartingWith(
             this.keyPrefix,
+            this.type,
         );
         this.records = cachedRecords.sort((a, b) => cmp(a.key, b.key));
 
@@ -62,7 +68,10 @@ class RecordStore {
         this.records.splice(i, 0, newRecord);
 
         // Write-through to dbManager
-        dbManager.set(this.keyPrefix + newRecord.key.toString(), newRecord);
+        dbManager.set(
+            this.type + SEPARATOR + this.keyPrefix + newRecord.key.toString(),
+            newRecord,
+        );
     }
 
     public delete(key: Key) {


### PR DESCRIPTION
## Summary

- Wrong saved data from the persistent storage because the `fakeIndexedDB` is controlling 2 types, the `object` and the `index` type, but inside the `getValuesForKeysStartingWith` function, we don't check the type, just checking with the `startsWith` of the `prefix`, so if we have the `test/books/` and `test/books/by_title/` prefixes, the filtering condition will be wrong
- Just a minor changes for the Typescript syntax
### Solution

- Adding the `type` between the `index` and `object` of the RecordStore to solve this issue

### Demo

#### The bug version

- Working correctly for the first run (no cached data)

<img width="931" alt="Screenshot 2024-11-29 at 04 16 59" src="https://github.com/user-attachments/assets/84a201dc-748e-4b4c-949f-86de543aa240">

- Bug on the next run

<img width="998" alt="Screenshot 2024-11-29 at 04 17 31" src="https://github.com/user-attachments/assets/4d7663cc-7852-4f8e-9e23-02b8c36ee04a">

### With the new code

- No cached data

<img width="793" alt="Screenshot 2024-11-29 at 04 22 07" src="https://github.com/user-attachments/assets/96ac2968-3c0f-4eff-a28d-9ecc0cc080ba">

- With cached data

<img width="941" alt="Screenshot 2024-11-29 at 04 18 58" src="https://github.com/user-attachments/assets/b724247a-41f3-4483-892f-195f2ca7c4e6">
