### PR TITLE
Fixing race conditions and index updates and index multivalue stores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,14 +29,14 @@
                 "eslint": "^8.57.0",
                 "eslint-config-prettier": "^9.1.0",
                 "glob": "^10.3.15",
-                "husky": "^9.0.11",
                 "jest": "^29.7.0",
                 "lint-staged": "^15.2.2",
                 "mocha": "^10.4.0",
                 "node-qunit-phantomjs": "^2.1.1",
                 "prettier": "^3.2.5",
                 "qunitjs": "^1.23.1",
-                "tsx": "^4.7.0",
+                "ts-node": "^10.9.2",
+                "tsx": "^4.7.1",
                 "typescript": "^5.4.5"
             },
             "engines": {
@@ -1868,6 +1868,30 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.23.1",
             "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
@@ -3406,6 +3430,34 @@
                 "@sinonjs/commons": "^3.0.0"
             }
         },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+            "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3907,6 +3959,13 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/argparse": {
             "version": "2.0.1",
@@ -5267,6 +5326,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -6800,21 +6866,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10.17.0"
-            }
-        },
-        "node_modules/husky": {
-            "version": "9.1.3",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.3.tgz",
-            "integrity": "sha512-ET3TQmQgdIu0pt+jKkpo5oGyg/4MQZpG6xcam5J5JyNJV+CBT23OBpCF15bKHKycRyMH9k6ONy8g2HdGIsSkMQ==",
-            "dev": true,
-            "bin": {
-                "husky": "bin.js"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/typicode"
             }
         },
         "node_modules/ieee754": {
@@ -9823,6 +9874,13 @@
                 "semver": "bin/semver"
             }
         },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/makeerror": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -12214,6 +12272,73 @@
                 "typescript": ">=4.2.0"
             }
         },
+        "node_modules/ts-node": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-esm": "dist/bin-esm.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ts-node/node_modules/acorn-walk": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.11.0"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/ts-node/node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
         "node_modules/tsx": {
             "version": "4.19.2",
             "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.2.tgz",
@@ -12484,6 +12609,13 @@
             "bin": {
                 "uuid": "bin/uuid"
             }
+        },
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",
@@ -12880,6 +13012,16 @@
             "dependencies": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
+            }
+        },
+        "node_modules/yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-indexeddb",
-    "version": "6.0.0",
+    "version": "6.0.2",
     "description": "Node IndexedDB: a pure JS Node implementation of the IndexedDB API",
     "homepage": "https://github.com/tylerweitzman/node-indexeddb",
     "repository": {

--- a/src/FDBFactory.ts
+++ b/src/FDBFactory.ts
@@ -258,7 +258,9 @@ class FDBFactory {
             for (const [dbName, dbStructure] of Object.entries(dbStructures)) {
                 const db = new Database(dbName, dbStructure.version);
                 this._databases.set(dbName, db);
-                console.log("Set    ", dbName, db);
+                if (process.env.DB_VERBOSE === "1") {
+                    console.log("Set    ", dbName, db);
+                }
             }
         } catch (error) {
             console.error("Error initializing databases:", error);

--- a/src/lib/Database.ts
+++ b/src/lib/Database.ts
@@ -22,7 +22,9 @@ class Database {
 
         // Load existing structure
         const dbStructure = dbManager.getDatabaseStructure(name);
-        console.log("Loaded db struct", dbStructure);
+        if (process.env.DB_VERBOSE === "1") {
+            console.log("Loaded db struct", dbStructure);
+        }
         if (dbStructure && dbStructure.version === version) {
             for (const [osName, osData] of Object.entries(
                 dbStructure.objectStores,

--- a/src/lib/Index.ts
+++ b/src/lib/Index.ts
@@ -90,6 +90,9 @@ class Index {
 
     // http://www.w3.org/TR/2015/REC-IndexedDB-20150108/#dfn-steps-for-storing-a-record-into-an-object-store (step 7)
     public storeRecord(newRecord: Record) {
+        // First remove any existing index entries for this record
+        this.records.deleteByValue(newRecord.key);
+
         let indexKey;
         try {
             indexKey = extractKey(this.keyPath, newRecord.value);
@@ -98,7 +101,6 @@ class Index {
                 // Invalid key is not an actual error, just means we do not store an entry in this index
                 return;
             }
-
             throw err;
         }
 
@@ -131,6 +133,10 @@ class Index {
                     throw new ConstraintError();
                 }
             }
+            this.records.add({
+                key: indexKey,
+                value: newRecord.key,
+            });
         } else {
             if (this.unique) {
                 for (const individualIndexKey of indexKey) {
@@ -140,14 +146,6 @@ class Index {
                     }
                 }
             }
-        }
-
-        if (!this.multiEntry || !Array.isArray(indexKey)) {
-            this.records.add({
-                key: indexKey,
-                value: newRecord.key,
-            });
-        } else {
             for (const individualIndexKey of indexKey) {
                 this.records.add({
                     key: individualIndexKey,

--- a/src/lib/Index.ts
+++ b/src/lib/Index.ts
@@ -6,7 +6,6 @@ import ObjectStore from "./ObjectStore.js";
 import RecordStore from "./RecordStore.js";
 import { Key, KeyPath, Record } from "./types.js";
 import valueToKey from "./valueToKey.js";
-import { PathUtils } from "./PathUtils.js";
 
 // http://www.w3.org/TR/2015/REC-IndexedDB-20150108/#dfn-index
 class Index {
@@ -29,34 +28,14 @@ class Index {
         unique: boolean,
     ) {
         this.rawObjectStore = rawObjectStore;
+        // this.records.setKeyPrefix(); //is this right? or should the index name not be there?
         this.name = name;
-
-        // Use PathUtils to create the index path
-        const indexPath = PathUtils.createIndexPath(
-            this.rawObjectStore.rawDatabase.name,
-            this.rawObjectStore.name,
-            this.name,
-        );
-        this.records = new RecordStore(indexPath, "index");
-
+        const keyPrefix = `${this.rawObjectStore.rawDatabase.name}/${this.rawObjectStore.name}/${this.name}/`;
+        this.records = new RecordStore(keyPrefix, "index");
         this.keyPath = keyPath;
         this.multiEntry = multiEntry;
         this.unique = unique;
-
-        // Initialize from disk if records exist
-        this.initializeFromDisk();
-    }
-
-    private initializeFromDisk() {
-        // Check if we have any records for this index
-        const iterator = this.records.values()[Symbol.iterator]();
-        const firstRecord = iterator.next();
-        if (!firstRecord.done) {
-            console.log(
-                `Index ${this.name} has existing records, marking as initialized`,
-            );
-            this.initialized = true;
-        }
+        // console.log("IDB|Index constructor,", this.name, this.rawObjectStore.name);
     }
 
     // http://www.w3.org/TR/2015/REC-IndexedDB-20150108/#dfn-steps-for-retrieving-a-value-from-an-index
@@ -180,30 +159,23 @@ class Index {
 
     public initialize(transaction: FDBTransaction) {
         if (this.initialized) {
-            console.log(`Index ${this.name} already initialized`);
-            return;
+            throw new Error("Index already initialized");
         }
 
-        const initializeOperation = () => {
-            try {
-                console.log(
-                    `Initializing index ${this.name} from object store records`,
-                );
-                // Create index based on current value of objectstore
-                for (const record of this.rawObjectStore.records.values()) {
-                    this.storeRecord(record);
-                }
-
-                this.initialized = true;
-                console.log(`Index ${this.name} initialization complete`);
-            } catch (err) {
-                console.error(`Error initializing index ${this.name}:`, err);
-                transaction._abort(err.name);
-            }
-        };
-
         transaction._execRequestAsync({
-            operation: initializeOperation,
+            operation: () => {
+                try {
+                    // Create index based on current value of objectstore
+                    for (const record of this.rawObjectStore.records.values()) {
+                        this.storeRecord(record);
+                    }
+
+                    this.initialized = true;
+                } catch (err) {
+                    // console.error(err);
+                    transaction._abort(err.name);
+                }
+            },
             source: null,
         });
     }

--- a/src/lib/LevelDBManager.ts
+++ b/src/lib/LevelDBManager.ts
@@ -193,7 +193,7 @@ class LevelDBManager {
         if (!this.isLoaded) throw new Error("Database not loaded yet");
 
         // Check if this is an index entry
-        const isIndex = key.includes("/by_");
+        const isIndex = key.startsWith("index/");
 
         // For index entries, we need to handle multiple values
         if (isIndex) {

--- a/src/lib/LevelDBManager.ts
+++ b/src/lib/LevelDBManager.ts
@@ -4,12 +4,15 @@ import { Record, DatabaseStructure } from "./types.js";
 import Database from "./Database.js";
 import { RecordStoreType, SEPARATOR } from "./RecordStore.js";
 
+type RecordValue = Record | Record[];
+
 class LevelDBManager {
     private static instance: LevelDBManager;
     private db: Level<string, any>;
-    private cache: Map<string, Record> = new Map();
+    private cache: Map<string, RecordValue> = new Map();
     public isLoaded: boolean = false;
     private databaseStructures: Map<string, DatabaseStructure> = new Map();
+    private pendingWrites: Promise<void>[] = [];
 
     private constructor(dbName: string) {
         this.db = new Level<string, any>(dbName, { valueEncoding: "json" });
@@ -30,6 +33,7 @@ class LevelDBManager {
             try {
                 const dbListJson = await this.db.get("__db_list__");
                 dbList = JSON.parse(dbListJson);
+                console.log("Loaded database list:", dbList);
             } catch (error) {
                 if (error.code === "LEVEL_NOT_FOUND") {
                     console.log(
@@ -67,6 +71,7 @@ class LevelDBManager {
                 if (!key.startsWith("__")) {
                     // Skip structure keys
                     this.cache.set(key, value);
+                    console.log("Loaded key:", key, "with value:", value);
                 }
             }
 
@@ -106,16 +111,42 @@ class LevelDBManager {
         const dbList = Array.from(this.databaseStructures.keys());
         if (!dbList.includes(db.name)) {
             dbList.push(db.name);
-            await this.db.put("__db_list__", JSON.stringify(dbList));
+            // Create promises for both operations
+            const dbListPromise = this.db
+                .put("__db_list__", JSON.stringify(dbList))
+                .catch((err) => {
+                    console.error("Error saving database list:", err);
+                    throw err;
+                })
+                .finally(() => {
+                    const index = this.pendingWrites.indexOf(dbListPromise);
+                    if (index > -1) {
+                        this.pendingWrites.splice(index, 1);
+                    }
+                });
+
+            this.pendingWrites.push(dbListPromise);
+            await dbListPromise;
         }
-        // console.log("Saving database structure", dbStructure);
+
         this.databaseStructures.set(db.name, dbStructure);
 
-        await this.db.put(
-            `__db_structure__${db.name}`,
-            JSON.stringify(dbStructure),
-        );
-        // console.log("Successfully saved");
+        const structurePromise = this.db
+            .put(`__db_structure__${db.name}`, JSON.stringify(dbStructure))
+            .catch((err) => {
+                console.error("Error saving database structure:", err);
+                throw err;
+            })
+            .finally(() => {
+                const index = this.pendingWrites.indexOf(structurePromise);
+                if (index > -1) {
+                    this.pendingWrites.splice(index, 1);
+                }
+            });
+
+        console.log("Saving database structure", dbStructure);
+        this.pendingWrites.push(structurePromise);
+        await structurePromise;
     }
 
     public getDatabaseStructure(dbName: string): DatabaseStructure | undefined {
@@ -123,41 +154,97 @@ class LevelDBManager {
     }
 
     public getAllDatabaseStructures(): { [dbName: string]: DatabaseStructure } {
-        if (!dbManager.isLoaded)
+        if (!this.isLoaded)
             throw new Error(
                 "Database not loaded yet. Manually call await dbManager.loadCache() before awaiting import of real-indexeddb/auto in any module",
             );
         return Object.fromEntries(this.databaseStructures);
     }
 
-    public get(key: string): Record | undefined {
+    public get(key: string): RecordValue | undefined {
         if (!this.isLoaded) throw new Error("Database not loaded yet");
         return this.cache.get(key);
     }
 
-    public set(key: string, value: Record) {
+    public set(key: string, value: RecordValue) {
         if (!this.isLoaded) throw new Error("Database not loaded yet");
+
+        // Check if this is an index entry
+        const isIndex = key.includes("/by_");
+
+        // For index entries, we need to handle multiple values
+        if (isIndex) {
+            const existingValue = this.cache.get(key);
+            if (existingValue) {
+                // Convert to array format if needed
+                const existingArray = Array.isArray(existingValue)
+                    ? existingValue
+                    : [existingValue];
+                const valueArray = Array.isArray(value) ? value : [value];
+
+                // Merge arrays and remove duplicates
+                const combinedValues = [...existingArray];
+                for (const val of valueArray) {
+                    if (
+                        !combinedValues.some(
+                            (existing) =>
+                                existing.key === val.key &&
+                                existing.value === val.value,
+                        )
+                    ) {
+                        combinedValues.push(val);
+                    }
+                }
+                value = combinedValues;
+            }
+        }
+
         this.cache.set(key, value);
-        this.db
+
+        const writePromise = this.db
             .put(key, value)
-            .catch((err) => console.error("Error persisting record:", err));
+            .catch((err) => {
+                console.error("Error persisting record:", err);
+                throw err;
+            })
+            .finally(() => {
+                const index = this.pendingWrites.indexOf(writePromise);
+                if (index > -1) {
+                    this.pendingWrites.splice(index, 1);
+                }
+            });
+
+        this.pendingWrites.push(writePromise);
     }
 
     public delete(key: string) {
         if (!this.isLoaded) throw new Error("Database not loaded yet");
         this.cache.delete(key);
-        this.db
+
+        const deletePromise = this.db
             .del(key)
             .catch((err) =>
                 console.error("Error deleting record from persistence:", err),
-            );
+            )
+            .finally(() => {
+                const index = this.pendingWrites.indexOf(deletePromise);
+                if (index > -1) {
+                    this.pendingWrites.splice(index, 1);
+                }
+            });
+
+        this.pendingWrites.push(deletePromise);
     }
 
     public async deleteDatabaseStructure(dbName: string) {
         this.databaseStructures.delete(dbName);
         const dbList = Array.from(this.databaseStructures.keys());
-        await this.db.put("__db_list__", JSON.stringify(dbList));
-        await this.db.del(`__db_structure__${dbName}`);
+        const promises = [
+            this.db.put("__db_list__", JSON.stringify(dbList)),
+            this.db.del(`__db_structure__${dbName}`),
+        ];
+        this.pendingWrites.push(...promises);
+        await Promise.all(promises);
     }
 
     public getKeysStartingWith(prefix: string): string[] {
@@ -176,7 +263,30 @@ class LevelDBManager {
 
         return Array.from(this.cache.entries())
             .filter(([key]) => key.startsWith(validatedPrefix))
-            .map(([, value]) => value);
+            .map(([, value]) => (Array.isArray(value) ? value : [value]))
+            .flat();
+    }
+
+    public async flushWrites(): Promise<void> {
+        console.log("Flushing writes to disk", this.pendingWrites.length);
+        if (this.pendingWrites.length === 0) return;
+
+        const writes = [...this.pendingWrites];
+        this.pendingWrites = [];
+
+        try {
+            // Process writes sequentially instead of in parallel
+            for (const write of writes) {
+                await write;
+            }
+            console.log(
+                `Successfully flushed ${writes.length} pending writes to disk`,
+            );
+        } catch (error) {
+            // Put failed writes back in the queue in their original order
+            this.pendingWrites.unshift(...writes);
+            throw error;
+        }
     }
 }
 

--- a/src/lib/LevelDBManager.ts
+++ b/src/lib/LevelDBManager.ts
@@ -2,9 +2,8 @@ import * as path from "path";
 import { Level } from "level";
 import { Record, DatabaseStructure } from "./types.js";
 import Database from "./Database.js";
-import { RecordStoreType, SEPARATOR } from "./RecordStore.js";
-import { PathUtils } from "./PathUtils.js";
-
+import { RecordStoreType } from "./RecordStore.js";
+import { SEPARATOR } from "./PathUtils.js";
 type RecordValue = Record | Record[];
 
 class LevelDBManager {
@@ -40,6 +39,7 @@ class LevelDBManager {
                     console.log(
                         "No existing database list found. Starting with an empty database.",
                     );
+                    // Initialize with an empty database list
                     await this.db.put("__db_list__", JSON.stringify([]));
                 } else {
                     throw error;
@@ -49,7 +49,7 @@ class LevelDBManager {
             for (const dbName of dbList) {
                 try {
                     const dbStructureJson = await this.db.get(
-                        PathUtils.createStructurePath(dbName),
+                        `__db_structure__${dbName}`,
                     );
                     const dbStructure: DatabaseStructure =
                         JSON.parse(dbStructureJson);
@@ -64,12 +64,12 @@ class LevelDBManager {
                     }
                 }
             }
+            // console.log('Loaded databaseStructures:', this.databaseStructures);
 
             // Load actual data
             for await (const [key, value] of this.db.iterator()) {
                 if (!key.startsWith("__")) {
                     // Skip structure keys
-                    console.log(`Loading key type: ${key.split("/")[0]}`); // Log the type (index/object)
                     this.cache.set(key, value);
                     console.log("Loaded key:", key, "with value:", value);
                 }
@@ -86,7 +86,6 @@ class LevelDBManager {
     }
 
     public async saveDatabaseStructure(db: Database) {
-        console.log("Saving database structure for:", db.name);
         const dbStructure: DatabaseStructure = {
             name: db.name,
             version: db.version,
@@ -94,7 +93,6 @@ class LevelDBManager {
         };
 
         for (const [name, objectStore] of db.rawObjectStores) {
-            console.log(`Processing object store: ${name}`);
             dbStructure.objectStores[name] = {
                 keyPath: objectStore.keyPath,
                 autoIncrement: objectStore.autoIncrement,
@@ -102,9 +100,6 @@ class LevelDBManager {
             };
 
             for (const [indexName, index] of objectStore.rawIndexes) {
-                console.log(
-                    `Processing index: ${indexName} for store: ${name}`,
-                );
                 dbStructure.objectStores[name].indexes[indexName] = {
                     keyPath: index.keyPath,
                     multiEntry: index.multiEntry,
@@ -116,7 +111,7 @@ class LevelDBManager {
         const dbList = Array.from(this.databaseStructures.keys());
         if (!dbList.includes(db.name)) {
             dbList.push(db.name);
-            console.log("Updating database list:", dbList);
+            // Create promises for both operations
             const dbListPromise = this.db
                 .put("__db_list__", JSON.stringify(dbList))
                 .catch((err) => {
@@ -137,10 +132,7 @@ class LevelDBManager {
         this.databaseStructures.set(db.name, dbStructure);
 
         const structurePromise = this.db
-            .put(
-                PathUtils.createStructurePath(db.name),
-                JSON.stringify(dbStructure),
-            )
+            .put(`__db_structure__${db.name}`, JSON.stringify(dbStructure))
             .catch((err) => {
                 console.error("Error saving database structure:", err);
                 throw err;
@@ -176,14 +168,43 @@ class LevelDBManager {
 
     public set(key: string, value: RecordValue) {
         if (!this.isLoaded) throw new Error("Database not loaded yet");
-        console.log(`Setting key: ${key} with value:`, value);
+
+        // Check if this is an index entry
+        const isIndex = key.includes("/by_");
+
+        // For index entries, we need to handle multiple values
+        if (isIndex) {
+            const existingValue = this.cache.get(key);
+            if (existingValue) {
+                // Convert to array format if needed
+                const existingArray = Array.isArray(existingValue)
+                    ? existingValue
+                    : [existingValue];
+                const valueArray = Array.isArray(value) ? value : [value];
+
+                // Merge arrays and remove duplicates
+                const combinedValues = [...existingArray];
+                for (const val of valueArray) {
+                    if (
+                        !combinedValues.some(
+                            (existing) =>
+                                existing.key === val.key &&
+                                existing.value === val.value,
+                        )
+                    ) {
+                        combinedValues.push(val);
+                    }
+                }
+                value = combinedValues;
+            }
+        }
 
         this.cache.set(key, value);
 
         const writePromise = this.db
             .put(key, value)
             .catch((err) => {
-                console.error("Error writing record to persistence:", err);
+                console.error("Error persisting record:", err);
                 throw err;
             })
             .finally(() => {
@@ -198,15 +219,13 @@ class LevelDBManager {
 
     public delete(key: string) {
         if (!this.isLoaded) throw new Error("Database not loaded yet");
-        console.log(`Deleting key: ${key}`);
         this.cache.delete(key);
 
         const deletePromise = this.db
             .del(key)
-            .catch((err) => {
-                console.error("Error deleting record from persistence:", err);
-                throw err;
-            })
+            .catch((err) =>
+                console.error("Error deleting record from persistence:", err),
+            )
             .finally(() => {
                 const index = this.pendingWrites.indexOf(deletePromise);
                 if (index > -1) {
@@ -222,7 +241,7 @@ class LevelDBManager {
         const dbList = Array.from(this.databaseStructures.keys());
         const promises = [
             this.db.put("__db_list__", JSON.stringify(dbList)),
-            this.db.del(PathUtils.createStructurePath(dbName)),
+            this.db.del(`__db_structure__${dbName}`),
         ];
         this.pendingWrites.push(...promises);
         await Promise.all(promises);
@@ -236,31 +255,16 @@ class LevelDBManager {
     }
 
     public getValuesForKeysStartingWith(
-        storePath: string,
+        prefix: string,
         type: RecordStoreType,
     ): Record[] {
         if (!this.isLoaded) throw new Error("Database not loaded yet");
-        const validatedPrefix = `${type}${SEPARATOR}${storePath}`;
-        console.log(`Getting values for ${type} store at path: ${storePath}`);
+        const validatedPrefix = type + SEPARATOR + prefix;
 
-        const records: Record[] = [];
-        for (const [key, value] of this.cache) {
-            if (key.startsWith(validatedPrefix)) {
-                console.log(
-                    `Found matching record - key: ${key}, value:`,
-                    value,
-                );
-                if (Array.isArray(value)) {
-                    records.push(...value);
-                } else {
-                    records.push(value);
-                }
-            }
-        }
-        console.log(
-            `Found ${records.length} records for ${type} store at ${storePath}`,
-        );
-        return records;
+        return Array.from(this.cache.entries())
+            .filter(([key]) => key.startsWith(validatedPrefix))
+            .map(([, value]) => (Array.isArray(value) ? value : [value]))
+            .flat();
     }
 
     public async flushWrites(): Promise<void> {

--- a/src/lib/ObjectStore.ts
+++ b/src/lib/ObjectStore.ts
@@ -7,6 +7,8 @@ import KeyGenerator from "./KeyGenerator.js";
 import RecordStore from "./RecordStore.js";
 import { Key, KeyPath, Record, RollbackLog } from "./types.js";
 import dbManager from "./LevelDBManager.js";
+import { PathUtils } from "./PathUtils.js";
+import { noOverwrite } from "./globals.js";
 // http://www.w3.org/TR/2015/REC-IndexedDB-20150108/#dfn-object-store
 class ObjectStore {
     public deleted = false;
@@ -31,20 +33,26 @@ class ObjectStore {
         this.name = name;
         this.keyPath = keyPath;
         this.autoIncrement = autoIncrement;
-        const keyPrefix = `${this.rawDatabase.name}/${this.name}/`;
-        this.records = new RecordStore(keyPrefix, "object");
-        // this.records.setKeyPrefix(keyPrefix);
-        // console.log(
-        //     "IDB|ObjectStore constructor,",
-        //     this.name,
-        //     this.rawDatabase.name,
-        // );
+
+        // Use PathUtils to create the store path
+        const storePath = PathUtils.createStorePath(
+            this.rawDatabase.name,
+            this.name,
+            "object",
+        );
+        this.records = new RecordStore(storePath, "object");
+
         const dbStructure = dbManager.getDatabaseStructure(rawDatabase.name);
         if (dbStructure && dbStructure.objectStores[name]) {
             const osData = dbStructure.objectStores[name];
+            console.log(
+                `Creating indexes for ${name}:`,
+                Object.keys(osData.indexes),
+            );
             for (const [indexName, indexData] of Object.entries(
                 osData.indexes,
             )) {
+                console.log(`Creating index ${indexName} with:`, indexData);
                 const index = new Index(
                     this,
                     indexName,
@@ -58,7 +66,6 @@ class ObjectStore {
     }
 
     public async saveStructure() {
-        // Get the current database structure
         const dbStructure = dbManager.getDatabaseStructure(
             this.rawDatabase.name,
         );
@@ -141,7 +148,7 @@ class ObjectStore {
     // http://www.w3.org/TR/2015/REC-IndexedDB-20150108/#dfn-steps-for-storing-a-record-into-an-object-store
     public storeRecord(
         newRecord: Record,
-        noOverwrite: boolean,
+        skipIndexes = false,
         rollbackLog?: RollbackLog,
     ) {
         if (this.keyPath !== null) {
@@ -222,9 +229,18 @@ class ObjectStore {
         }
 
         // Update indexes
-        for (const rawIndex of this.rawIndexes.values()) {
-            if (rawIndex.initialized) {
-                rawIndex.storeRecord(newRecord);
+        if (!skipIndexes) {
+            for (const rawIndex of this.rawIndexes.values()) {
+                console.log(
+                    `Checking index ${rawIndex.name}, initialized: ${rawIndex.initialized}`,
+                );
+                if (rawIndex.initialized) {
+                    console.log(
+                        `Storing record in index ${rawIndex.name}:`,
+                        newRecord,
+                    );
+                    rawIndex.storeRecord(newRecord);
+                }
             }
         }
 

--- a/src/lib/ObjectStore.ts
+++ b/src/lib/ObjectStore.ts
@@ -56,8 +56,17 @@ class ObjectStore {
                     indexData.multiEntry,
                     indexData.unique,
                 );
+                index.initialized = true;
                 this.rawIndexes.set(indexName, index);
             }
+        }
+        if (process.env.DB_VERBOSE === "1") {
+            console.log(
+                this.rawDatabase.name,
+                this.name,
+                "rawIndexes",
+                this.rawIndexes,
+            );
         }
     }
 

--- a/src/lib/ObjectStore.ts
+++ b/src/lib/ObjectStore.ts
@@ -7,6 +7,7 @@ import KeyGenerator from "./KeyGenerator.js";
 import RecordStore from "./RecordStore.js";
 import { Key, KeyPath, Record, RollbackLog } from "./types.js";
 import dbManager from "./LevelDBManager.js";
+import { PathUtils } from "./PathUtils.js";
 // http://www.w3.org/TR/2015/REC-IndexedDB-20150108/#dfn-object-store
 class ObjectStore {
     public deleted = false;
@@ -31,7 +32,10 @@ class ObjectStore {
         this.name = name;
         this.keyPath = keyPath;
         this.autoIncrement = autoIncrement;
-        const keyPrefix = `${this.rawDatabase.name}/${this.name}/`;
+        const keyPrefix = PathUtils.createObjectStoreKeyPath(
+            this.rawDatabase.name,
+            this.name,
+        );
         this.records = new RecordStore(keyPrefix, "object");
         // this.records.setKeyPrefix(keyPrefix);
         // console.log(

--- a/src/lib/PathUtils.ts
+++ b/src/lib/PathUtils.ts
@@ -1,6 +1,6 @@
 import { RecordStoreType } from "./RecordStore.js";
 import { Key } from "./types.js";
-export const SEPARATOR = "_";
+export const SEPARATOR = "/";
 
 export class PathUtils {
     static createKeyPath(
@@ -8,7 +8,7 @@ export class PathUtils {
         type: RecordStoreType,
         key: Key,
     ): string {
-        return type + SEPARATOR + keyPrefix + key.toString();
+        return PathUtils.createPrefixPath(keyPrefix, type) + key.toString();
     }
 
     static createPrefixPath(keyPrefix: string, type: RecordStoreType): string {

--- a/src/lib/PathUtils.ts
+++ b/src/lib/PathUtils.ts
@@ -1,49 +1,17 @@
-import { RecordStoreType, SEPARATOR } from "./RecordStore.js";
+import { RecordStoreType } from "./RecordStore.js";
 import { Key } from "./types.js";
+export const SEPARATOR = "_";
 
 export class PathUtils {
-    static createStorePath(
-        dbName: string,
-        storeName: string,
+    static createKeyPath(
+        keyPrefix: string,
         type: RecordStoreType,
-        key?: Key,
+        key: Key,
     ): string {
-        const basePath = `${type}${SEPARATOR}${dbName}/${storeName}`;
-        return key !== undefined ? `${basePath}/${key}` : basePath;
+        return type + SEPARATOR + keyPrefix + key.toString();
     }
 
-    static createIndexPath(
-        dbName: string,
-        storeName: string,
-        indexName: string,
-        key?: Key,
-    ): string {
-        return (
-            this.createStorePath(dbName, storeName, "index", key) +
-            (key ? "" : `/${indexName}`)
-        );
-    }
-
-    static createStructurePath(dbName: string, storeName?: string): string {
-        if (storeName) {
-            return `__db_structure__${dbName}/${storeName}`;
-        }
-        return `__db_structure__${dbName}`;
-    }
-
-    static parseStorePath(path: string): {
-        type: RecordStoreType;
-        dbName: string;
-        storeName: string;
-        key?: string;
-    } {
-        const [type, ...parts] = path.split(SEPARATOR);
-        const [dbName, storeName, key] = parts[0].split("/");
-        return {
-            type: type as RecordStoreType,
-            dbName,
-            storeName,
-            key,
-        };
+    static createPrefixPath(keyPrefix: string, type: RecordStoreType): string {
+        return type + SEPARATOR + keyPrefix;
     }
 }

--- a/src/lib/PathUtils.ts
+++ b/src/lib/PathUtils.ts
@@ -3,15 +3,19 @@ import { Key } from "./types.js";
 export const SEPARATOR = "/";
 
 export class PathUtils {
-    static createKeyPath(
+    static DB_LIST_KEY = "__db_list__";
+    static DB_STRUCTURE_KEY = "__db_structure__";
+    static SPECIAL_KEYS = [PathUtils.DB_LIST_KEY, PathUtils.DB_STRUCTURE_KEY];
+
+    static createObjectStoreKeyPath(dbName: string, storeName: string): string {
+        return `${dbName}/${storeName}/`;
+    }
+    // For record store
+    static createRecordStoreKeyPath(
         keyPrefix: string,
         type: RecordStoreType,
         key: Key,
     ): string {
-        return PathUtils.createPrefixPath(keyPrefix, type) + key.toString();
-    }
-
-    static createPrefixPath(keyPrefix: string, type: RecordStoreType): string {
-        return type + SEPARATOR + keyPrefix;
+        return type + SEPARATOR + keyPrefix + key.toString();
     }
 }

--- a/src/lib/PathUtils.ts
+++ b/src/lib/PathUtils.ts
@@ -1,0 +1,49 @@
+import { RecordStoreType, SEPARATOR } from "./RecordStore.js";
+import { Key } from "./types.js";
+
+export class PathUtils {
+    static createStorePath(
+        dbName: string,
+        storeName: string,
+        type: RecordStoreType,
+        key?: Key,
+    ): string {
+        const basePath = `${type}${SEPARATOR}${dbName}/${storeName}`;
+        return key !== undefined ? `${basePath}/${key}` : basePath;
+    }
+
+    static createIndexPath(
+        dbName: string,
+        storeName: string,
+        indexName: string,
+        key?: Key,
+    ): string {
+        return (
+            this.createStorePath(dbName, storeName, "index", key) +
+            (key ? "" : `/${indexName}`)
+        );
+    }
+
+    static createStructurePath(dbName: string, storeName?: string): string {
+        if (storeName) {
+            return `__db_structure__${dbName}/${storeName}`;
+        }
+        return `__db_structure__${dbName}`;
+    }
+
+    static parseStorePath(path: string): {
+        type: RecordStoreType;
+        dbName: string;
+        storeName: string;
+        key?: string;
+    } {
+        const [type, ...parts] = path.split(SEPARATOR);
+        const [dbName, storeName, key] = parts[0].split("/");
+        return {
+            type: type as RecordStoreType,
+            dbName,
+            storeName,
+            key,
+        };
+    }
+}

--- a/src/lib/RecordStore.ts
+++ b/src/lib/RecordStore.ts
@@ -9,9 +9,8 @@ import {
 import cmp from "./cmp.js";
 import { Key, Record } from "./types.js";
 import dbManager from "./LevelDBManager.js";
-
-export type RecordStoreType = "object" | "index";
-export const SEPARATOR = "_";
+export type RecordStoreType = "object" | "index" | "";
+import { PathUtils, SEPARATOR } from "./PathUtils.js";
 
 class RecordStore {
     private records: Record[] = [];
@@ -68,8 +67,11 @@ class RecordStore {
         this.records.splice(i, 0, newRecord);
 
         // Write-through to dbManager - for index types, write all records with the same key
-        const key =
-            this.type + SEPARATOR + this.keyPrefix + newRecord.key.toString();
+        const key = PathUtils.createKeyPath(
+            this.keyPrefix,
+            this.type,
+            newRecord.key,
+        );
         if (this.type === "index") {
             const sameKeyRecords = this.records.filter(
                 (r) => r.key === newRecord.key,

--- a/src/lib/RecordStore.ts
+++ b/src/lib/RecordStore.ts
@@ -34,7 +34,9 @@ class RecordStore {
             this.type,
         );
         this.records = cachedRecords.sort((a, b) => cmp(a.key, b.key));
-
+        if (this.type === "index") {
+            console.log("INDEX_LOAD", this.keyPrefix, this.records);
+        }
         // Optionally, remove these records from dbManager's cache to save memory
         // cachedRecords.forEach(record => {
         //     dbManager.delete(this.keyPrefix + record.key.toString());
@@ -67,7 +69,7 @@ class RecordStore {
         this.records.splice(i, 0, newRecord);
 
         // Write-through to dbManager - for index types, write all records with the same key
-        const key = PathUtils.createKeyPath(
+        const key = PathUtils.createRecordStoreKeyPath(
             this.keyPrefix,
             this.type,
             newRecord.key,
@@ -134,6 +136,7 @@ class RecordStore {
         return deletedRecords;
     }
     public values(range?: FDBKeyRange, direction: "next" | "prev" = "next") {
+        console.log("values()", this.keyPrefix, this.records);
         return {
             [Symbol.iterator]: () => {
                 let i: number;

--- a/src/lib/RecordStore.ts
+++ b/src/lib/RecordStore.ts
@@ -67,11 +67,22 @@ class RecordStore {
 
         this.records.splice(i, 0, newRecord);
 
-        // Write-through to dbManager
-        dbManager.set(
-            this.type + SEPARATOR + this.keyPrefix + newRecord.key.toString(),
-            newRecord,
-        );
+        // Write-through to dbManager - for index types, write all records with the same key
+        const key =
+            this.type + SEPARATOR + this.keyPrefix + newRecord.key.toString();
+        if (this.type === "index") {
+            const sameKeyRecords = this.records.filter(
+                (r) => r.key === newRecord.key,
+            );
+            dbManager.set(
+                key,
+                sameKeyRecords.length === 1
+                    ? sameKeyRecords[0]
+                    : sameKeyRecords,
+            );
+        } else {
+            dbManager.set(key, newRecord);
+        }
     }
 
     public delete(key: Key) {

--- a/src/lib/globals.ts
+++ b/src/lib/globals.ts
@@ -1,0 +1,1 @@
+export let noOverwrite = false;


### PR DESCRIPTION
There are a few issues with node-indexeddb that needed fixing.
1. Needed to add an option to flush the writes because sometimes levelDB needs an extra 2 seconds to finish writing to disk. Call `await dbManager.flushWrites()` prior to letting the user exit your node process.
2. New PR ensures that the levelDB save operations are in sequence rather than parallel to avoid race conditions
3. Indexes weren't being properly initialized from levelDB
4. Key paths have been centralized and separated by type (index vs object) to account for edge cases, especially for fixing range queries and getAll queries for indexes